### PR TITLE
Make top-level directory an Eclipse project

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>git_TestFramework</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
This makes it easier to use Eclipse to manipulate files (e.g., pom.xml)
in the top-level directory.