### PR TITLE
Added pom file for Ciera compilation

### DIFF
--- a/TestFramework/pom.xml
+++ b/TestFramework/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.xtuml</groupId>
+  <artifactId>TestFramework</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+  <build>
+    <resources>
+      <resource>
+        <directory>${project.basedir}</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>models/**/*.xtuml</include>
+          <include>.project</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>${project.build.directory}/generated-sources/java</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>**/*.properties</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
+</project>


### PR DESCRIPTION
The pom file allows the TestFramework to be included in any build.
Assuming the TestFramework resides at the same level as the project with
which it will be built, it can be included in the build by adding this
line to the top-level pom file for the build:
<module>../TestFramework/TestFramework</module>