### PR TITLE
Complete

### DIFF
--- a/TestFramework/models/TestFramework/Components/TestSequencer/Datatypes/Datatypes.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/Datatypes/Datatypes.xtuml
@@ -24,7 +24,7 @@ INSERT INTO GD_MD
 	200,
 	150,
 	0,
-	'',
+	'4.1.17',
 	'TestFramework::Components::TestSequencer::Datatypes');
 INSERT INTO GD_GE
 	VALUES ("4e97dda7-b6bf-4803-b688-89562668dea7",
@@ -32,7 +32,7 @@ INSERT INTO GD_GE
 	"f118c998-732a-4398-a820-4480fa8cdb21",
 	52,
 	0,
-	'TestFramework::Components::TestSequencer::Datatypes::tsStatus');
+	'TestFramework::Components::TestSequencer::Datatypes::caseStatus');
 INSERT INTO GD_SHP
 	VALUES ("4e97dda7-b6bf-4803-b688-89562668dea7");
 INSERT INTO GD_NCS
@@ -50,6 +50,30 @@ INSERT INTO DIM_ELE
 	VALUES ("4e97dda7-b6bf-4803-b688-89562668dea7",
 	0,
 	"00000000-0000-0000-0000-000000000000");
+INSERT INTO GD_GE
+	VALUES ("78b48fe5-43fa-45e6-bcf6-8071b3d01fe4",
+	"756cb780-4e1a-403e-a7a4-b06484eebd50",
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	52,
+	0,
+	'TestFramework::Components::TestSequencer::Datatypes::observationStatus');
+INSERT INTO GD_SHP
+	VALUES ("78b48fe5-43fa-45e6-bcf6-8071b3d01fe4");
+INSERT INTO GD_NCS
+	VALUES ("78b48fe5-43fa-45e6-bcf6-8071b3d01fe4");
+INSERT INTO DIM_ND
+	VALUES (200.000000,
+	150.000000,
+	"78b48fe5-43fa-45e6-bcf6-8071b3d01fe4");
+INSERT INTO DIM_GE
+	VALUES (440.000000,
+	0.000000,
+	"78b48fe5-43fa-45e6-bcf6-8071b3d01fe4",
+	"00000000-0000-0000-0000-000000000000");
+INSERT INTO DIM_ELE
+	VALUES ("78b48fe5-43fa-45e6-bcf6-8071b3d01fe4",
+	0,
+	"00000000-0000-0000-0000-000000000000");
 INSERT INTO DIM_DIA
 	VALUES ("756cb780-4e1a-403e-a7a4-b06484eebd50",
 	'',
@@ -60,7 +84,7 @@ INSERT INTO DIM_DIA
 INSERT INTO S_DT
 	VALUES ("f118c998-732a-4398-a820-4480fa8cdb21",
 	"00000000-0000-0000-0000-000000000000",
-	'tsStatus',
+	'caseStatus',
 	'Status values associated with the lifecycles of various instances.',
 	'');
 INSERT INTO S_EDT
@@ -79,7 +103,7 @@ INSERT INTO S_ENUM
 	"e97954b6-ad67-4097-8f63-6ee04dcc4a2a");
 INSERT INTO S_ENUM
 	VALUES ("246d264d-b5e3-4c0a-8edf-cac26e0b843b",
-	'timedout',
+	'timedoutX',
 	'',
 	"f118c998-732a-4398-a820-4480fa8cdb21",
 	"0bc7b0ab-9856-4f1d-9b1c-153ef1f84f32");
@@ -101,6 +125,56 @@ INSERT INTO PE_PE
 	"0a55d6bd-e7c8-4286-a6b3-77c525cf64b9",
 	"00000000-0000-0000-0000-000000000000",
 	3);
+INSERT INTO S_DT
+	VALUES ("8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"00000000-0000-0000-0000-000000000000",
+	'observationStatus',
+	'Status values associated with the lifecycles of various instances.',
+	'');
+INSERT INTO S_EDT
+	VALUES ("8dbc5f97-fc0a-492e-a0da-e7c134178780");
+INSERT INTO S_ENUM
+	VALUES ("20145d01-b08f-4096-983c-74fe98f176b9",
+	'created',
+	'',
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"00000000-0000-0000-0000-000000000000");
+INSERT INTO S_ENUM
+	VALUES ("fb2f5bac-9bc7-4200-a9c9-278105876e75",
+	'started',
+	'',
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"20145d01-b08f-4096-983c-74fe98f176b9");
+INSERT INTO S_ENUM
+	VALUES ("97a52f21-f2d0-4ea3-a556-c3b2aaa91865",
+	'timedout',
+	'',
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"fd45ca27-2160-4598-9400-a1d5776a6b79");
+INSERT INTO S_ENUM
+	VALUES ("adf7ec44-77ab-41cf-98f9-99d3f995fd53",
+	'failed',
+	'',
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"97a52f21-f2d0-4ea3-a556-c3b2aaa91865");
+INSERT INTO S_ENUM
+	VALUES ("0c3aee5f-89ba-4688-85ce-afcb501bc44c",
+	'completed',
+	'',
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"adf7ec44-77ab-41cf-98f9-99d3f995fd53");
+INSERT INTO S_ENUM
+	VALUES ("fd45ca27-2160-4598-9400-a1d5776a6b79",
+	'observing',
+	'',
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	"fb2f5bac-9bc7-4200-a9c9-278105876e75");
+INSERT INTO PE_PE
+	VALUES ("8dbc5f97-fc0a-492e-a0da-e7c134178780",
+	1,
+	"0a55d6bd-e7c8-4286-a6b3-77c525cf64b9",
+	"00000000-0000-0000-0000-000000000000",
+	3);
 INSERT INTO PE_PE
 	VALUES ("0a55d6bd-e7c8-4286-a6b3-77c525cf64b9",
 	1,
@@ -112,74 +186,125 @@ INSERT INTO C_C_PROXY
 	"00000000-0000-0000-0000-000000000000",
 	"00000000-0000-0000-0000-000000000000",
 	'TestSequencer',
-	'Summary description:
+	'Overview:
 
-A service supporting the sequencing of the steps involved in running a suite of test cases.
-A test suite contains an ordered set of test buckets.
-Each test bucket contains at least one test case; typically several related tests.
-A test case consists of one or more sequences of stimuli and following observations.
-Multiple sequences of stimuli run concurrently in a test case execution.
-A stimulus effects some changes in a system under test.
-Following observations may evaluate the response of the system to such a stimulus.
-Observations may evaluate sequentially in a defined order, or concurrently if order is undefined.
-Observations may be triggered to evaluate on some occurence, or may poll, repeatedly evaluating.
-Observations may be limited in duration; failure to succeed within this time constitutes failure.
-Time delays can be interspersed between stimuli and observations and between observations.
-All observations following a stimulus must complete before the next stimulus is injected
-If all observations are found acceptable, the test case is deemed to be successful.
-If any observation fails, the test case ceases execution: all sequences discontinue.
-A test case may be associated with instances of requirements to support coverage reporting.
-
-Discussion:
+This is a service to automate the running of a suite of multiple self-checking test cases 
+including rudimentary reporting of results and requirements coverage.
 
 Typically a self-checking test case has three primary components:
 1. Establish pre-conditions.
 2. Inject stimulus.
-3. Verify post-stimulus conditions.
-Often, the injection of stimuli and the verification of post-conditions
+3. Verify (observe) post-stimulus conditions.
+Often, the injection of stimuli and the observation of post-conditions
 are intermixed, as the test case injects a stimulus, verifies the response(s), 
 injects additional stimuli, and so on.
+
+While stimulus actions and observation measurements are subject-matter specific, the organization 
+of sequencing stimuli and adjudication of success or failure are not. Hence this service.
+
+
+Summary description:
 
 This subject matter-independent Test Sequencer service asumes the burdens of sequencing, timer 
 management, requirements coverage tracking and summary reporting for multi-threaded test cases 
 ordered in test buckets within a test suite.
 
 A testbench, with subject matter-specific details of stimuli and observations, can use this 
-Test Sequencer service to manage its interaction with a system under test.
+service to manage its interaction with a system under test.
 
-To use the service, a testbench must derive its test bucket, stimuli and observation classes from 
-the supertype classes provided in the sample testbench component and use the operations supplied 
-in the supertypes to interface with the service.
+Each test case is defined in data as instances of stimuli and observations.  Test cases 
+are typically organized into buckets.  For example, a testbench might have a bucket containing
+all nominal (good-path) test cases and perhaps several buckets containing off-nominal (unusual
+situations, error-recovery, etc.) test cases.  Or, test buckets could be organized around 
+sections of the requirements specification.  The scheme for organizing test cases into buckets
+is entirely at the discretion of the test engineer.
 
-In principle, a testbench registers a test suite with the service, supplying a name and optionally 
-selecting a timescale which will be default for the testcases it will contain. The testbench adds 
-test buckets to the suite and populates each bucket with test cases comprised of stimuli and 
-observations. A test bucket contains at least one test case, but commonly a number of cases which 
-share some common purpose, such as comprehensive testing of a subgroup of requirements. 
+A test suite is configured to contain one or more test buckets which are added to the suite in order.
+Each test bucket configures at least one test case; typically several related tests.
 
-Optionally, a testbench can register instances of requirements with the service. There is provision 
-for associating any such requirement with one or more test case instances; the service will provide 
-a summary report on requirements coverage at completion of testing.
+When all test buckets have been added to the test suite, the test suite is signalled to execute.
+In turn, each bucket is signalled to configure its test cases and run them.
 
-A test case may choose to specify pre-conditions which should be established before the case is run.
-This is done by associating an instance of the testbench preconditions class which is configured with 
-the desired values and an operation to inject these values when invoked at test case initialization.
+A test case consists of one or more sequences of stimuli and following observations.
+The instances in the testbench have counterparts in the test service where sequencing is managed.
+The testbench creates stimuli and observation instances which add themselves to the test service.
+When the test bucket configuration is complete its test cases are run in order.
+Running a test case involves appropriate invocation of the stimulus interactions with the system 
+under test and evaluating the system''s response as measured by observations.
 
-As the testbench constructs test cases, using provided operations of the stimulus and observation 
-supertypes to add its specific stimuli and observation instances, the sequencer builds corresponding 
-sequences in the Test Sequencer service context. 
 
-The testbench test bucket, stimulus and observation subtype classes must provide instances which will 
-respond to the invocations of injection and observation operations on the testbench supertype when 
-triggered by the sequencing service as it works through the series of test cases. 
-The testbench supertypes also provide operations to signal comkpletion/failure to the service.
+Some details:
 
-The test cases are created in an instance based operation of a test bucket subtype. This operation 
-will be invoked for each test bucket subtype as the sequencer runs through the set of buckets that 
-constitute a test suite. The invoked operation creates subtype instances of stimulus and observation 
-arranging them in order. Stimuli are added to a stimulus sequence - of which there must be at least 
-one created for a test case. If there are multiple sequences of stimuli they will run concurrently.
+Multiple sequences of stimuli may run concurrently in a test case execution.
+A stimulus effects some changes in a system under test.
+Following observations may evaluate the response of the system to such a stimulus.
+Observations may evaluate sequentially in a defined order, or concurrently if so configured.
+Observations may be triggered to evaluate on some occurence, or may poll, repeatedly evaluating.
+Observations may be limited in duration; failure to succeed within this time constitutes failure.
+Time delays can be interspersed between stimuli and observations and between observations.
+Time resolution values are propagated as defaults down the hierarchy from test suite to observation and 
+can be overridden at any level - from where they now become defaults.
+Polling intervals can be specified indpendently of time resolution values.
+All observations following a stimulus must complete before the next stimulus is injected
+If all observations are found acceptable, the test case is deemed to be successful.
+If any observation fails, the test case ceases execution: all sequences discontinue, and the test
+case is deemed as having failed.
+A test case may be associated with instances of requirements to support coverage reporting.
+
+
+Establishing pre-conditions:
+
+The service sends a message to the testbench indicating that the next test case to execute 
+should be initialized.  Upon receiving this message, the testbench may establish pre-conditions
+for the specified test case.  This might include configuring hardware resources (either
+simulated or real), sending interface messages to the system under test, or (if the testbench
+is inside the same component as the system under test) direct manipulation of the system under
+test.
+
+
+Test case failure:
+
+A failing test typically indicates one of two possibilities.  Either the system under test is 
+not behaving as specified or the test (or its supporting tooling) is in error.  Any test case
+with one or more failing observations is deemed as having failed.  An identifier for each failing 
+observation is emitted to the log, and the data (instances of stimuli and observations) associated
+with the failing test case are retained, enabling many failures to be isolated through analysis of 
+the log or inspection of the instance population. 
+
+
+Usage:
+
+For an example usage of the service, see the test bench for the Carpark application located here:
+https://github.com/johnrwolfe/CarPark/tree/master/CarParkTestbench. 
+
+The testbench test bucket, stimulus and observation classes must provide instances which will 
+respond to the sequencing services signals to inject stimuli and initiate observations as the service 
+works through the series of test cases. These signals carry identifiers of type unique_id which 
+identify instances in the testbench. A practical way to satisfy these conditions is to create each 
+of these testbench classes as a subtype of a test bucket, stimulus or observation class supertype. 
+Pass the identifier of the supertype when adding instances to the sequencing service. 
+On receipt of a signal from the service navigate to the subtype and carry out the appropriate action.
+The service must be signaled with appropriate completion/failure of these actions in order to progress.
+
+As the sequencer runs through the set of buckets that constitute a test suite it will signal an
+initialization action for each test bucket. This should invoke an operation that creates the subtype 
+instances of stimulus and observation for each test case, submitting identifiers in order.
+When test case creation for a test bucket is complete the testbench signals for start of execution.
+
+Stimuli are added to a stimulus sequence of which there must be at least one created for a test case. 
+If there are multiple sequences of stimuli they will run concurrently.
+
 Observations are each appended to a specific stimulus and may be separated by chosen time delays.
+Where the order in which observations should evaluate after a stimulus is unpredictable, they may be 
+configured to evaluate concurrently; each one must succeed to consitute completion. If, however, 
+during test case execution it is determined that a triggered operation is no longer required, there 
+is a provision to "remove" it without causing failure of the test case.
+
+An observation may be configured with optional timers: one limits the duration until lack of success 
+will be deemed a timeout failure; the other may determine a polling frequency for re-evaluation.
+These timers may be independently configured with resolutions which may differ. The overall duration 
+and the polling interval are specified as values using those configured resolution units.
+Example: observations with timeouts specified in seconds may poll at some number of milliseconds.
 
 An observation may be configured to poll, repeatedly evaluating system conditions until it completes 
 by reporting success, or fails after some time limit. Alternatively, invocation of an evaluation can
@@ -188,12 +313,12 @@ the system under test. This is achieved by associating a specific key with the o
 a sequence "assess" signal, with a key value, will trigger evaluation of any current observations 
 with a matching key. If desired, such an ''asynchronous'' observation may be associated with a separate 
 stimulus sequence, allowing other sets of observations to proceed while it waits to be triggered.
+A ''hybrid'' observation may wait for an initial trigger and subsequently poll in search of success.
 
 Associated with each stimulus sequence there is one interval timer. A stimulus or observation can 
 start (or restart) the timer on a sequence. A subsequent observation may read the elapsed time since 
 the timer was started - and may optionally reset the timer value on reading. Interval timer 
-resolution defaults to that of the test case, but can be overridden.
-',
+resolution defaults to that of the sequence time resolution, but can be overridden.',
 	0,
 	"00000000-0000-0000-0000-000000000000",
 	0,

--- a/TestFramework/models/TestFramework/Components/TestSequencer/Datatypes/Datatypes.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/Datatypes/Datatypes.xtuml
@@ -102,17 +102,11 @@ INSERT INTO S_ENUM
 	"f118c998-732a-4398-a820-4480fa8cdb21",
 	"e97954b6-ad67-4097-8f63-6ee04dcc4a2a");
 INSERT INTO S_ENUM
-	VALUES ("246d264d-b5e3-4c0a-8edf-cac26e0b843b",
-	'timedoutX',
-	'',
-	"f118c998-732a-4398-a820-4480fa8cdb21",
-	"0bc7b0ab-9856-4f1d-9b1c-153ef1f84f32");
-INSERT INTO S_ENUM
 	VALUES ("05ecd1e6-b55b-40fb-8d0c-79ec43bb33bb",
 	'failed',
 	'',
 	"f118c998-732a-4398-a820-4480fa8cdb21",
-	"246d264d-b5e3-4c0a-8edf-cac26e0b843b");
+	"0bc7b0ab-9856-4f1d-9b1c-153ef1f84f32");
 INSERT INTO S_ENUM
 	VALUES ("cc1be859-f8ee-424b-b475-1b9b4ba2ab34",
 	'completed',

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Observation/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Observation/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -431,7 +431,7 @@ INSERT INTO SM_ACT
 	VALUES ("12dc0ee7-5913-4c32-961d-b1470ebfa768",
 	"a21d52cf-6581-475c-99b1-ce226c484bc4",
 	1,
-	'self.obsStatus = tsStatus::failed;',
+	'self.status = observationStatus::failed;',
 	'',
 	0);
 INSERT INTO SM_MOAH
@@ -448,7 +448,7 @@ INSERT INTO SM_ACT
 	'// An observation has been deemed to complete successfully.
 // Attempt to promote any immediately succeeding observations to observing status.
 
-self.obsStatus = tsStatus::completed;
+self.status = observationStatus::completed;
 self.CancelTimers();
 select one stimulus related by self->Stimulus[R115.''is currently observing for''];
 if ( not_empty stimulus )  // this was not an untimed triggered observation
@@ -462,7 +462,7 @@ end if;
 select one stimulus related by self->Stimulus[R105.''is made after''];
 select any other_observation related by stimulus->Observation[R105.''will trigger'']
  where ( selected.sequence_number == self.sequence_number )
-  and ( selected.obsStatus != tsStatus::completed );
+  and ( selected.status != observationStatus::completed );
 if ( empty other_observation )
   select many observations related by stimulus->Observation[R105.''will trigger'']
    where ( selected.sequence_number == self.sequence_number + 1 );
@@ -516,15 +516,16 @@ INSERT INTO SM_ACT
 	VALUES ("8365397f-d928-40a1-a143-1f5b67717161",
 	"a21d52cf-6581-475c-99b1-ce226c484bc4",
 	1,
-	'// Following a stimuulus injection, an observation is now ''readied'' for evaluation.
+	'// Following a stimulus injection, an observation is now ''readied'' for evaluation.
 // If it has been created with a timeout timer, then start the timer now.
 // If it is not associated with a trigger - for which it must wait - then proceed.
 
-self.obsStatus = tsStatus::started;
+self.status = observationStatus::started;
 self.StartDurationLimitTimer();
 if ( not self.isDelay)  // delays are a "non-observing" observation.
   select one trigger related by self->Trigger[R127.''delays until triggered by''];
   if ( empty trigger )  // not waiting to be triggered by "assess"
+    self.status = observationStatus::observing;
     send TESTBENCH::InvokeObservation( observationId:self.assignedID );
   end if;
 end if;',
@@ -558,8 +559,7 @@ INSERT INTO SM_ACT
 	"a21d52cf-6581-475c-99b1-ce226c484bc4",
 	1,
 	'LOG::LogFailure( message:"SEQ Observation timed out " );      
-self.obsStatus = tsStatus::timedout;
-',
+self.status = observationStatus::timedout;',
 	'',
 	0);
 INSERT INTO SM_TAH

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Observation/Observation.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Observation/Observation.xtuml
@@ -158,7 +158,7 @@ create object instance new_observation of Observation;
 new_observation.assignedID = param.observationId;
 new_observation.isDelay = param.isDelay;
 new_observation.sequence_number = cursor.observations;
-new_observation.obsStatus = tsStatus::created;
+new_observation.status = observationStatus::created;
 if ( param.triggerKey != "" )
   select any trigger from instances of Trigger
    where ( selected.KeyValue == param.triggerKey );
@@ -339,18 +339,18 @@ INSERT INTO O_ATTR
 	VALUES ("24be76cd-6e25-43bb-ad99-9b1b9098100a",
 	"575e1db4-0e95-46f9-afaa-e41935d0b11f",
 	"461e232d-e064-4ec7-991a-9ab6353d0a53",
-	'obsStatus',
+	'status',
 	'Tracks the status of the observation through creation to completion/failure.',
 	'',
-	'obsStatus',
+	'status',
 	0,
-	"f118c998-732a-4398-a820-4480fa8cdb21",
+	"8dbc5f97-fc0a-492e-a0da-e7c134178780",
 	'',
 	'');
 INSERT INTO S_DT_PROXY
-	VALUES ("f118c998-732a-4398-a820-4480fa8cdb21",
+	VALUES ("8dbc5f97-fc0a-492e-a0da-e7c134178780",
 	"00000000-0000-0000-0000-000000000000",
-	'tsStatus',
+	'observationStatus',
 	'Status values associated with the lifecycles of various instances.',
 	'',
 	'../../Datatypes/Datatypes.xtuml');
@@ -469,11 +469,6 @@ INSERT INTO O_ATTR
 INSERT INTO O_ID
 	VALUES (0,
 	"575e1db4-0e95-46f9-afaa-e41935d0b11f");
-INSERT INTO O_OIDA
-	VALUES ("0590bf3e-aa12-4afe-99e1-e6823fdf25bc",
-	"575e1db4-0e95-46f9-afaa-e41935d0b11f",
-	0,
-	'assignedID');
 INSERT INTO O_ID
 	VALUES (1,
 	"575e1db4-0e95-46f9-afaa-e41935d0b11f");

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Observation/Observation.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Observation/Observation.xtuml
@@ -404,7 +404,8 @@ INSERT INTO O_ATTR
 	"575e1db4-0e95-46f9-afaa-e41935d0b11f",
 	"00000000-0000-0000-0000-000000000000",
 	'assignedID',
-	'A supplied value which identifies the counterpart entity in the test client.',
+	'A supplied value which identifies the counterpart entity in the test client.
+Note: this would ideally be marked as an identifier - but that causes editor parse errors.',
 	'',
 	'assignedID',
 	0,

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Requirement/Requirement.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Requirement/Requirement.xtuml
@@ -48,14 +48,13 @@ INSERT INTO O_TFR
 	'LOG::LogInfo( message:"** Successfully Tested Requirements **" );
 select many reqs from instances of Requirement;
 for each req in reqs
-  select many tcs related by req->TestCase[R101.''is tested by''];
+  select many tcs related by req->TestCase[R101.''is tested by'']
+   where ( selected.status == caseStatus::completed );
   if ( not_empty tcs )
     LOG::LogReal( message:req.prefix, r:req.number);
     for each tc in tcs
-      if ( tc.tcStatus == tsStatus::completed )
-    	LOG::LogInfo( message:" tested by successful test case " + tc.testCaseLabel );
-        req.tested = True;
-      end if;
+      LOG::LogInfo( message:" tested by successful test case " + tc.testCaseLabel );
+      req.tested = True;
     end for;
   end if;
 end for; 
@@ -64,13 +63,12 @@ select many reqs from instances of Requirement
 if ( not_empty reqs )
   LOG::LogInfo( message:"** Failed Test Case Requirements **" );
   for each req in reqs
-    select many tcs related by req->TestCase[R101.''is tested by''];
+    select many tcs related by req->TestCase[R101.''is tested by'']
+     where ( selected.status != caseStatus::completed );
     if ( not_empty tcs )
       LOG::LogReal( message:req.prefix, r:req.number);
       for each tc in tcs
-        if ( tc.tcStatus != tsStatus::completed )
-    	  LOG::LogInfo( message:" associated with failed test case " + tc.testCaseLabel );
-        end if;
+    	LOG::LogInfo( message:" associated with failed test case " + tc.testCaseLabel );
       end for;
     end if;
   end for;

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Stimulus/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Stimulus/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -316,8 +316,7 @@ INSERT INTO SM_ACT
 	VALUES ("9575dca7-20f7-4629-be05-a79b623b7c2b",
 	"04dd84b7-ce74-4c3f-8a18-138da22fce83",
 	1,
-	'self.stmStatus = tsStatus::started;
-send TESTBENCH::InjectStimulus( stimulusId:self.assignedID );
+	'send TESTBENCH::InjectStimulus( stimulusId:self.assignedID );
 select many observations related by self->Observation[R105.''will trigger'']
  where ( selected.sequence_number == 1 );
 for each observation in observations
@@ -338,8 +337,7 @@ INSERT INTO SM_ACT
 	VALUES ("d833db70-90b5-4adf-bcfb-9bc622599229",
 	"04dd84b7-ce74-4c3f-8a18-138da22fce83",
 	1,
-	'self.stmStatus = tsStatus::completed;
-select one seq related by self->StimulusSequence[R116.''is active for''];
+	'select one seq related by self->StimulusSequence[R116.''is active for''];
 generate StimulusSequence2:StimulusDone to seq;',
 	'',
 	0);
@@ -354,11 +352,13 @@ INSERT INTO SM_ACT
 	VALUES ("6f9680f7-ad6b-47d5-b9fc-a1bf9ffaced5",
 	"04dd84b7-ce74-4c3f-8a18-138da22fce83",
 	1,
-	'select one seq related by self->StimulusSequence[R116.''is active for''];
-self.stmStatus = tsStatus::failed;
+	'// Report failure both to sequence and to test case.
+self.failed = True;
+select one seq related by self->StimulusSequence[R116.''is active for''];
 LOG::LogFailure( message:"SEQ Stimulus incomplete in sequence " + seq.seqLabel );
-select one tc related by seq->TestCase[R119.''is execution thread for''];
-generate TestCase5:StimulusIncomplete to tc;',
+seq.failed = True;
+select one testcase related by seq->TestCase[R119.''is execution thread for''];
+generate TestCase5:StimulusIncomplete to testcase;',
 	'',
 	0);
 INSERT INTO SM_TAH

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Stimulus/Stimulus.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Stimulus/Stimulus.xtuml
@@ -25,6 +25,7 @@ select any seq related by tc->StimulusSequence[R119.''executes'']
 if ( not_empty seq )
   create object instance new_stimulus of Stimulus;
   new_stimulus.assignedID = param.stimulusId;
+  new_stimulus. failed = False;
   seq.lastStimulus = seq.lastStimulus + 1;
   new_stimulus.numberInSeq = seq.lastStimulus; 
   select one first_stimulus related by seq->Stimulus[R104.''will first inject''];
@@ -110,7 +111,8 @@ INSERT INTO O_ATTR
 	"98a0e5ff-b2a0-4159-b98d-6232d74cdff0",
 	"00000000-0000-0000-0000-000000000000",
 	'assignedID',
-	'A supplied value which identifies the counterpart entity in the client testbench',
+	'A supplied value which identifies the counterpart entity in the client testbench.
+Note: this would ideally be marked as an identifier - but that causes editor parse errors.',
 	'',
 	'assignedID',
 	0,

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Stimulus/Stimulus.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Stimulus/Stimulus.xtuml
@@ -25,7 +25,6 @@ select any seq related by tc->StimulusSequence[R119.''executes'']
 if ( not_empty seq )
   create object instance new_stimulus of Stimulus;
   new_stimulus.assignedID = param.stimulusId;
-  new_stimulus.stmStatus = tsStatus::created;
   seq.lastStimulus = seq.lastStimulus + 1;
   new_stimulus.numberInSeq = seq.lastStimulus; 
   select one first_stimulus related by seq->Stimulus[R104.''will first inject''];
@@ -186,29 +185,17 @@ INSERT INTO O_ATTR
 	VALUES ("82ce7e81-f40b-47a1-8b45-8480b5f83a28",
 	"98a0e5ff-b2a0-4159-b98d-6232d74cdff0",
 	"be145dc9-8cda-4f3a-a335-ec60440c3648",
-	'stmStatus',
+	'failed',
 	'Tracks the status of the stimulus through creation to completion/failure of any following observations.',
 	'',
-	'stmStatus',
+	'failed',
 	0,
-	"f118c998-732a-4398-a820-4480fa8cdb21",
+	"ba5eda7a-def5-0000-0000-000000000001",
 	'',
-	'');
-INSERT INTO S_DT_PROXY
-	VALUES ("f118c998-732a-4398-a820-4480fa8cdb21",
-	"00000000-0000-0000-0000-000000000000",
-	'tsStatus',
-	'Status values associated with the lifecycles of various instances.',
-	'',
-	'../../Datatypes/Datatypes.xtuml');
+	'false');
 INSERT INTO O_ID
 	VALUES (0,
 	"98a0e5ff-b2a0-4159-b98d-6232d74cdff0");
-INSERT INTO O_OIDA
-	VALUES ("66a641e5-550e-435e-bccc-9b80b78659ca",
-	"98a0e5ff-b2a0-4159-b98d-6232d74cdff0",
-	0,
-	'assignedID');
 INSERT INTO O_ID
 	VALUES (1,
 	"98a0e5ff-b2a0-4159-b98d-6232d74cdff0");

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/StimulusSequence/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/StimulusSequence/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -208,8 +208,7 @@ INSERT INTO SM_ACT
 	VALUES ("f2945ceb-9428-42d6-b31a-1fe6f396c769",
 	"cbf2fb30-3a61-468f-8153-06abe12f07cd",
 	1,
-	'self.seqStatus = tsStatus::created;
-select one stimulus related by self->Stimulus[R104.''will first inject''];
+	'select one stimulus related by self->Stimulus[R104.''will first inject''];
 if ( not_empty stimulus )
   relate self to stimulus across R116.''is processing'';
 end if;
@@ -227,7 +226,7 @@ INSERT INTO SM_ACT
 	VALUES ("5714e897-b6b9-404a-8733-d0c6e82514c7",
 	"cbf2fb30-3a61-468f-8153-06abe12f07cd",
 	1,
-	'self.seqStatus = tsStatus::started;',
+	'',
 	'',
 	0);
 INSERT INTO SM_TAH

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/StimulusSequence/StimulusSequence.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/StimulusSequence/StimulusSequence.xtuml
@@ -45,11 +45,10 @@ INSERT INTO O_TFR
 	'Notify test case of sequence completion',
 	"ba5eda7a-def5-0000-0000-000000000000",
 	1,
-	'self.seqStatus = tsStatus::completed;
-LOG::LogInfo( message:"SEQ Stimulus sequence complete " + self.seqLabel );
-select one tc related by self->TestCase[R119.''is execution thread for''];
-generate TestCase3:SequenceComplete to tc;
-',
+	'LOG::LogInfo( message:"SEQ Stimulus sequence complete " + self.seqLabel );
+select one testcase related by self->TestCase[R119.''is execution thread for''];
+unrelate self from testcase across R119.''is execution thread for'';
+generate TestCase3:SequenceComplete to testcase;',
 	1,
 	'',
 	"00000000-0000-0000-0000-000000000000",
@@ -121,21 +120,14 @@ INSERT INTO O_ATTR
 	VALUES ("95b56ef1-8098-454b-9fef-203a680cbe09",
 	"0ee731ba-4221-4650-a6e6-a00a6b1f7ee7",
 	"ce363601-8e98-4cbe-b4d3-b03e48c3e581",
-	'seqStatus',
+	'failed',
 	'Tracks status',
 	'',
-	'seqStatus',
+	'failed',
 	0,
-	"f118c998-732a-4398-a820-4480fa8cdb21",
+	"ba5eda7a-def5-0000-0000-000000000001",
 	'',
-	'');
-INSERT INTO S_DT_PROXY
-	VALUES ("f118c998-732a-4398-a820-4480fa8cdb21",
-	"00000000-0000-0000-0000-000000000000",
-	'tsStatus',
-	'Status values associated with the lifecycles of various instances.',
-	'',
-	'../../Datatypes/Datatypes.xtuml');
+	'false');
 INSERT INTO O_NBATTR
 	VALUES ("703a6d5c-e46d-46ca-87cc-c42b3f7824ca",
 	"0ee731ba-4221-4650-a6e6-a00a6b1f7ee7");

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestBucket/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestBucket/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -273,13 +273,10 @@ INSERT INTO SM_ACT
 	'// Initiate execution of a currently active test case.
 // If none, finish up this bucket.
 
-select one tc related by self->TestCase[R117.''is currently running''];
-if ( not_empty tc )
-  generate TestCase1:InitializeCase to tc;
+select one testcase related by self->TestCase[R117.''is currently running''];
+if ( not_empty testcase )
+  generate TestCase1:InitializeCase to testcase;
 else
-  if ( self.bktStatus != tsStatus::failed )
-    self.bktStatus = tsStatus::completed;
-  end if;
   generate TestBucket4:TestingFinished to self;
 end if;',
 	'',
@@ -344,7 +341,6 @@ INSERT INTO SM_ACT
 	'// Start executing the test cases in this bucket.
 // Select the first test case and ready it for activation.
 
-self.bktStatus = tsStatus::started;
 select one tc related by self->TestCase[R112.''will first execute''];
 if ( not_empty tc )
   relate tc to self across R117.''is active for'';
@@ -393,9 +389,8 @@ INSERT INTO SM_ACT
 	VALUES ("814a8a55-32b9-4770-987a-790224383f32",
 	"3be63f3c-c125-4392-81ae-903e75b9eb89",
 	1,
-	'self.bktStatus = tsStatus::failed;
-LOG::LogFailure( message:"SEQ No tests executed for empty bucket " + self.bucketLabel );
-',
+	'self.failed = True;
+LOG::LogFailure( message:"SEQ No tests executed for empty bucket " + self.bucketLabel );',
 	'',
 	0);
 INSERT INTO GD_MD

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestBucket/TestBucket.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestBucket/TestBucket.xtuml
@@ -122,7 +122,8 @@ INSERT INTO O_ATTR
 	"cf812356-d586-4cdf-9c29-72003a1e9246",
 	"00000000-0000-0000-0000-000000000000",
 	'assignedID',
-	'An id passed in from the client testbench which can be used to identify an instance.',
+	'An id passed in from the client testbench which can be used to identify an instance.
+Note: this would ideally be marked as an identifier - but that causes editor parse errors.',
 	'',
 	'assignedID',
 	0,

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestBucket/TestBucket.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestBucket/TestBucket.xtuml
@@ -18,7 +18,7 @@ INSERT INTO O_TFR
 
 create object instance new_tc of TestCase;
 new_tc.testCaseLabel = param.caseLabel;
-new_tc.tcStatus = tsStatus::created;
+new_tc.status = caseStatus::created;
 select one first_case related by self->TestCase[R112.''will first execute''];
 if ( empty first_case )
   relate self to new_tc across R112.''will first execute'';
@@ -72,12 +72,12 @@ while ( not_empty tc )
   select one next_tc related by tc->TestCase[R114.''follows''];
   // Delete the sequences, stimuli and observations of successsful test cases
   // Keep all context for failed test case for diagnosis
-  if ( tc.tcStatus == tsStatus::completed )	
+  if ( tc.status == caseStatus::completed )	
     tc.Dismantle();
   end if; 
   tc = next_tc;
 end while;
-if ( self.bktStatus == tsStatus::completed )
+if ( not self.failed )
   send TESTBENCH::DeleteTestBucket( bucketId:self.assignedID );
 end if;',
 	1,
@@ -98,8 +98,8 @@ select one tc related by self->TestCase[R117.''is currently running''];
 unrelate self from tc across R117.''is currently running'';
 select one next_tc related by tc->TestCase[R114.''follows''];
 // Retain entire contents of unsuccessful test case for error analysis
-if ( tc.tcStatus != tsStatus::completed )
-  self.bktStatus = tsStatus::failed;	// inhibit deletion of client test bucket at clean-up
+if ( tc.status != caseStatus::completed )
+  self.failed = True;	// inhibit deletion of client test bucket at clean-up
 else
   // clean up the test case contents, but leave the test case instances for reporting.
   tc.Dismantle();
@@ -175,22 +175,15 @@ INSERT INTO O_ATTR
 	VALUES ("de9eb285-b54e-4445-80bb-62d345a4a89f",
 	"cf812356-d586-4cdf-9c29-72003a1e9246",
 	"9c0da15d-eace-4093-959c-0312f913dfbe",
-	'bktStatus',
+	'failed',
 	'This status is used to prevent client (testbench) teardown of a bucket which contains failed test cases.
 The bucket context is retained for diagnosis.',
 	'',
-	'bktStatus',
+	'failed',
 	0,
-	"f118c998-732a-4398-a820-4480fa8cdb21",
+	"ba5eda7a-def5-0000-0000-000000000001",
 	'',
-	'');
-INSERT INTO S_DT_PROXY
-	VALUES ("f118c998-732a-4398-a820-4480fa8cdb21",
-	"00000000-0000-0000-0000-000000000000",
-	'tsStatus',
-	'Status values associated with the lifecycles of various instances.',
-	'',
-	'../../Datatypes/Datatypes.xtuml');
+	'false');
 INSERT INTO O_NBATTR
 	VALUES ("f6606833-5b16-4e64-bae2-2db2e04e98e8",
 	"cf812356-d586-4cdf-9c29-72003a1e9246");
@@ -230,11 +223,6 @@ INSERT INTO O_ATTR
 INSERT INTO O_ID
 	VALUES (0,
 	"cf812356-d586-4cdf-9c29-72003a1e9246");
-INSERT INTO O_OIDA
-	VALUES ("467db403-b4d1-4eb4-a423-82cfe5bbf674",
-	"cf812356-d586-4cdf-9c29-72003a1e9246",
-	0,
-	'assignedID');
 INSERT INTO O_ID
 	VALUES (1,
 	"cf812356-d586-4cdf-9c29-72003a1e9246");

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestCase/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestCase/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -486,11 +486,11 @@ LOG::LogInfo( message:"SEQ Beginning test case stimulus Injection for " + self.t
 select many sequences related by self->StimulusSequence[R119.''executes''];
 if ( not_empty sequences )
   for each seq in sequences
-      generate StimulusSequence1:StartSequence to seq;
-      self.tcStatus = tsStatus::started;
+    generate StimulusSequence1:StartSequence to seq;
+    self.status = caseStatus::started;
   end for;
 end if;
-if ( self.tcStatus != tsStatus::started )
+if ( self.status != caseStatus::started )
   LOG::LogInfo( message:"SEQ Test case is empty!" );
   generate TestCase5:StimulusIncomplete to self;
 end if;',
@@ -509,7 +509,7 @@ INSERT INTO SM_ACT
 	1,
 	'// Test case is finished; determine disposition.
 
-if ( self.tcStatus == tsStatus::failed );
+if ( self.status == caseStatus::failed );
   LOG::LogInfo( message:"SEQ Test case FAILED: " + self.testCaseLabel );
 else
   LOG::LogInfo( message:"SEQ Test case passed: " + self.testCaseLabel );
@@ -560,8 +560,7 @@ INSERT INTO SM_ACT
 	1,
 	'// Wait for all sequences to complete
 
-select any sequence related by self->StimulusSequence[R119.''executes'']
- where (selected.seqStatus != tsStatus::completed );
+select any sequence related by self->StimulusSequence[R119.''executes''];
 if (empty sequence )
   generate TestCase4:InjectionComplete to self;
 end if;',
@@ -592,7 +591,7 @@ INSERT INTO SM_ACT
 	VALUES ("9951f53a-5342-4a29-bb2c-9aef75370457",
 	"f0ebf01e-2bd3-42c6-bcf3-763d336097bd",
 	1,
-	'self.tcStatus = tsStatus::completed;',
+	'self.status = caseStatus::completed;',
 	'',
 	0);
 INSERT INTO SM_TAH
@@ -623,7 +622,7 @@ INSERT INTO SM_ACT
 	'// Failure to complete any sequence fails the test case.
 // No further observations will evaluate.
 
-self.tcStatus = tsStatus::failed;
+self.status = caseStatus::failed;
 self.CancelObservations();
 generate TestCase5:StimulusIncomplete to self;',
 	'An observation has failed to complete successfully; the test case cancels all further activity.',

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestCase/TestCase.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestCase/TestCase.xtuml
@@ -113,10 +113,10 @@ INSERT INTO O_ATTR
 	VALUES ("5aa69826-1c07-4e6e-9e73-45f2ebcb5c4c",
 	"ec247a2b-53a1-4839-882c-db3bb2812c25",
 	"dc5df546-89e9-4051-8c3b-8e5f8f60a9e9",
-	'tcStatus',
+	'status',
 	'Completion status.',
 	'',
-	'tcStatus',
+	'status',
 	0,
 	"f118c998-732a-4398-a820-4480fa8cdb21",
 	'',
@@ -124,7 +124,7 @@ INSERT INTO O_ATTR
 INSERT INTO S_DT_PROXY
 	VALUES ("f118c998-732a-4398-a820-4480fa8cdb21",
 	"00000000-0000-0000-0000-000000000000",
-	'tsStatus',
+	'caseStatus',
 	'Status values associated with the lifecycles of various instances.',
 	'',
 	'../../Datatypes/Datatypes.xtuml');

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestSuite/TestSuite.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestSuite/TestSuite.xtuml
@@ -69,13 +69,13 @@ if ( empty next_bucket )
   if ( not self.retainAll )
     select many testcases from instances of TestCase;
     for each testcase in testcases
-      if ( testcase.tcStatus == tsStatus::completed )  // keep incomplete cases for error analysis.
+      if ( testcase.status == caseStatus::completed )  // keep incomplete cases for error analysis.
         delete object instance testcase;
       end if;
     end for;
     select many buckets from instances of TestBucket;
     for each bucket in buckets
-      if ( bucket.bktStatus == tsStatus::completed )
+      if ( not bucket.failed )
         delete object instance bucket;
       end if;
     end for;
@@ -127,10 +127,7 @@ else
     end if;
   end while;
   relate cursor to new_bucket across R113.''follows'';
-end if;
-new_bucket.bktStatus = tsStatus::created;
-
-',
+end if;',
 	1,
 	'',
 	"8a5d688d-f48b-465c-8930-167630d9c2a9",
@@ -211,30 +208,28 @@ while ( not_empty bucket )
    unrelate tc from bucket across R112.''is first in'';
   end if;
   while ( not_empty tc )
-   if ( tc.tcStatus == tsStatus::completed )
-    LOG::LogInfo( message:"Test case passed: " + tc.testCaseLabel );
-   end if;
-   if ( tc.tcStatus == tsStatus::failed )
-    LOG::LogFailure( message:"Test case failed; " + tc.testCaseLabel );
-    select any seq related by tc->StimulusSequence[R119.''executes''];
-    if ( not_empty seq )
+   if ( tc.status == caseStatus::created )
+     LOG::LogFailure( message:"Test case not run: " + tc.testCaseLabel );
+   elif ( tc.status == caseStatus::completed )
+     LOG::LogInfo( message:"Test case passed: " + tc.testCaseLabel );
+   elif ( tc.status == caseStatus::failed )
+    LOG::LogFailure( message:"Test case failed: " + tc.testCaseLabel );
+    select many seqs related by tc->StimulusSequence[R119.''executes'']
+     where ( selected.failed);
+    for each seq in seqs
       LOG::LogFailure( message:" in sequence " + seq.seqLabel );
       select one stm related by seq->Stimulus[R116.''is processing''];
       LOG::LogReal( message:" after stimulus ", r:stm.numberInSeq );
       select many observations related by stm->Observation[R115.''has active''];
       for each observation in observations
         LOG::LogReal( message:" observation ", r:observation.sequence_number );
-        if ( observation.obsStatus == tsStatus::failed )
+        if ( observation.status == observationStatus::failed )
           LOG::LogFailure( message:"Observation failed" );
-        end if;
-        if ( observation.obsStatus == tsStatus::timedout )
+        elif ( observation.status == observationStatus::timedout )
           LOG::LogInfo( message:"Observation timed out" );
         end if;
       end for;
-    end if;
-   end if;
-   if ( tc.tcStatus == tsStatus::created )
-    LOG::LogFailure( message:"Test case not run; " + tc.testCaseLabel );
+    end for;
    end if;
    select one next_tc related by tc->TestCase[R114.''follows''];
    if ( not_empty next_tc )

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestSuite/TestSuite.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestSuite/TestSuite.xtuml
@@ -108,6 +108,7 @@ end if;
 create object instance new_bucket of TestBucket;
 new_bucket.assignedID = param.bucketId;
 new_bucket.bucketLabel = param.bucketLabel;
+new_bucket.failed = False;
 
 // Propagate defaults for any timing that may be needed.
 new_bucket.timeScaleFactor = ts.timeScaleFactor;

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Trigger/Trigger.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/Trigger/Trigger.xtuml
@@ -36,6 +36,7 @@ for each observation in observations
       unrelate observation from stimulus across R115.''is currently observing for'';
     end if;
     if ( param.fire )
+      observation.status = observationStatus::observing;
       generate Observation1:Observe() to observation;  // go ahead and have it observe
     else
       generate Observation5:Unobserve() to observation;


### PR DESCRIPTION
Replaced status attribute with boolean failed in all except testcase and
observation; these get dedicated status enumerations.
Use association existence rather than status comparisons for completion
evaluations.
Support reporting for multiple failing stimuli sequences.
Format requirements report.
Remove assignedID's as identifiers - parse errors.
Tested with Payroll and CarPark appliations.
Fixes #51.