### PR TITLE
Complete

### DIFF
--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/StimulusSequence/StimulusSequence.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/StimulusSequence/StimulusSequence.xtuml
@@ -47,7 +47,6 @@ INSERT INTO O_TFR
 	1,
 	'LOG::LogInfo( message:"SEQ Stimulus sequence complete " + self.seqLabel );
 select one testcase related by self->TestCase[R119.''is execution thread for''];
-unrelate self from testcase across R119.''is execution thread for'';
 generate TestCase3:SequenceComplete to testcase;',
 	1,
 	'',

--- a/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestCase/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/TestFramework/models/TestFramework/Components/TestSequencer/TestSequencer/TestCase/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -558,10 +558,11 @@ INSERT INTO SM_ACT
 	VALUES ("409beb1f-c66f-4742-8cbe-d9ba06a01fc8",
 	"f0ebf01e-2bd3-42c6-bcf3-763d336097bd",
 	1,
-	'// Wait for all sequences to complete
+	'// Wait for all sequences to complete - no active stimulus present.
 
-select any sequence related by self->StimulusSequence[R119.''executes''];
-if (empty sequence )
+select any stimulus related by self->StimulusSequence[R119.''executes'']
+                                   ->Stimulus[R116.''is processing''];
+if (empty stimulus )
   generate TestCase4:InjectionComplete to self;
 end if;',
 	'',


### PR DESCRIPTION
Retain R119 for sequence (stimuli/observation) cleanup.
Use absence of active stimulus as end-of-test indicator.
Fixes #55.