### PR TITLE
Remove deprecated nature

### DIFF
--- a/TestFramework/.project
+++ b/TestFramework/.project
@@ -35,7 +35,6 @@
 	</buildSpec>
 	<natures>
 		<nature>org.xtuml.bp.core.xtumlnature</nature>
-		<nature>org.xtuml.bp.mc.c.source.MCNature</nature>
 		<nature>org.eclipse.cdt.core.cnature</nature>
 		<nature>org.eclipse.cdt.core.ccnature</nature>
 		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>


### PR DESCRIPTION
Apparently the C source nature is no longer required or supported by BP
7.